### PR TITLE
Newlogger

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -8,4 +8,4 @@ require 'capistrano/bundler'
 require 'capistrano/rails/migrations'
 
 
-Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -16,7 +16,7 @@ class StagesController < ApplicationController
   # GET /projects/1/stages/1.xml
   def show
     @stage = current_project.stages.find(params[:id])
-    @task_list = [['All tasks: ', '']] + @stage.list_tasks
+    @task_list = [['All tasks: ', '']] + @stage.list_tasks.collect{|task| [task[:name], task[:name]]}
     @can_edit_project = current_user.can_edit?(@project)
 
     respond_to do |format|

--- a/lib/capsize/capsize_setup.rb
+++ b/lib/capsize/capsize_setup.rb
@@ -8,6 +8,16 @@ namespace :load do
   end
 end
 
+task :custom_log do
+  deployment = Deployment.find(ENV['DEPLOYMENT_ID'])
+  $stdout.rewind
+  $stdout.each_line do |line|
+    deployment.log = (deployment.log || '') + line
+  end
+  deployment.save!
+  Rake::Task["custom_log"].reenable
+end
+
 def capsize_setup(stage)
   Rake::Task.define_task(stage.name) do
     set(:stage, stage.name.to_sym)

--- a/lib/capsize/capsize_setup.rb
+++ b/lib/capsize/capsize_setup.rb
@@ -11,10 +11,13 @@ end
 task :custom_log do
   deployment = Deployment.find(ENV['DEPLOYMENT_ID'])
   $stdout.rewind
+
   $stdout.each_line do |line|
-    deployment.log = (deployment.log || '') + line
+    deployment.log = (deployment.log || '') + line if $stdout.lineno > ENV['LINE_NO'].to_i
+    deployment.save!
   end
-  deployment.save!
+
+  ENV['LINE_NO'] = $stdout.lineno.to_s
   Rake::Task["custom_log"].reenable
 end
 

--- a/lib/capsize/capsize_setup.rb
+++ b/lib/capsize/capsize_setup.rb
@@ -9,15 +9,16 @@ namespace :load do
 end
 
 task :custom_log do
-  deployment = Deployment.find(ENV['DEPLOYMENT_ID'])
+  deployment = Deployment.find(ENV['deployment_id'])
+
+  line_number = $stdout.lineno
   $stdout.rewind
 
   $stdout.each_line do |line|
-    deployment.log = (deployment.log || '') + line if $stdout.lineno > ENV['LINE_NO'].to_i
-    deployment.save!
-  end
+    deployment.log = (deployment.log || '') + line if $stdout.lineno > line_number
+  end  
+  deployment.save!
 
-  ENV['LINE_NO'] = $stdout.lineno.to_s
   Rake::Task["custom_log"].reenable
 end
 

--- a/lib/capsize/deployer.rb
+++ b/lib/capsize/deployer.rb
@@ -16,6 +16,8 @@ module Capsize
 
     attr_accessor :logger
 
+    attr_reader :browser_log
+
     def initialize(deployment)
       @options = {
         :recipes => [],

--- a/lib/capsize/deployer.rb
+++ b/lib/capsize/deployer.rb
@@ -295,6 +295,7 @@ module Capsize
       $stdout = @browser_log
       $stdout.sync = true
       ENV['DEPLOYMENT_ID'] = deployment.id.to_s
+      ENV['LINE_NO'] = '0'
     end
 
     def close_output

--- a/lib/capsize/deployer.rb
+++ b/lib/capsize/deployer.rb
@@ -257,7 +257,7 @@ module Capsize
         end
           f.puts "after :#{deployment.stage.name}, :custom_log"
         %w{deploy:started deploy:updated deploy:published deploy:finished}.each do |task|
-          f.puts before_flow(task)
+          # f.puts before_flow(task)
           f.puts after_flow(task)
         end
       end
@@ -294,8 +294,7 @@ module Capsize
       @browser_log = StringIO.new
       $stdout = @browser_log
       $stdout.sync = true
-      ENV['DEPLOYMENT_ID'] = deployment.id.to_s
-      ENV['LINE_NO'] = '0'
+      ENV['deployment_id'] = deployment.id.to_s
     end
 
     def close_output

--- a/test/unit/capsize_deployer_test.rb
+++ b/test/unit/capsize_deployer_test.rb
@@ -817,14 +817,12 @@ class Capsize::DeployerTest < ActiveSupport::TestCase
     deployer = Capsize::Deployer.new(@deployment)
     deployer.set_output
     print 'thisshouldshowup'
-    deployer.log_output
+    deployer.close_output
     assert $stdout == STDOUT
     deployer.browser_log.rewind
 
     assert_match /thisshouldshowup/, deployer.browser_log.string
-    assert_match /thisshouldshowup/, @deployment.log
   end
-
 
   protected
 

--- a/test/unit/capsize_deployer_test.rb
+++ b/test/unit/capsize_deployer_test.rb
@@ -813,6 +813,18 @@ class Capsize::DeployerTest < ActiveSupport::TestCase
     remove_directory(@deployment.stage.project.capsize_project_name)
   end
 
+  def test_output_logs_in_browser_log
+    deployer = Capsize::Deployer.new(@deployment)
+    deployer.set_output
+    print 'thisshouldshowup'
+    deployer.log_output
+    assert $stdout == STDOUT
+    deployer.browser_log.rewind
+
+    assert_match /thisshouldshowup/, deployer.browser_log.string
+    assert_match /thisshouldshowup/, @deployment.log
+  end
+
 
   protected
 


### PR DESCRIPTION
Redirects Capsize output to capture the output of the Capistrano deploy flow and save to the deployment log in the db.
