### PR TITLE
Refactorlogger

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,6 +12,7 @@ class Project < ActiveRecord::Base
   validates_inclusion_of :template, :in => ProjectConfiguration.templates.keys
 
   after_create :create_template_defaults
+  before_save :remove_blank_extensions
 
   attr_accessible :name, :description, :template, :archived, :extensions
 
@@ -55,9 +56,9 @@ class Project < ActiveRecord::Base
     CapistranoExtensions.available_extensions
   end
 
-  def extensions
-    attributes["extensions"].reject!(&:blank?) if attributes["extensions"]
-    attributes["extensions"] || []
+  def remove_blank_extensions
+    return update_attribute("extensions", []) if attributes["extensions"].nil?
+    write_attribute("extensions", attributes["extensions"].reject(&:blank?))
   end
 
   # returns a better form of the project name for use inside Capistrano recipes

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -56,9 +56,8 @@ class Project < ActiveRecord::Base
   end
 
   def extensions
-    attributes["extensions"] ||= []
-    attributes["extensions"].reject!(&:blank?)
-    attributes["extensions"]
+    attributes["extensions"].reject!(&:blank?) if attributes["extensions"]
+    attributes["extensions"] || []
   end
 
   # returns a better form of the project name for use inside Capistrano recipes

--- a/db/migrate/20150223141212_change_project_extensions.rb
+++ b/db/migrate/20150223141212_change_project_extensions.rb
@@ -1,0 +1,10 @@
+class ChangeProjectExtensions < ActiveRecord::Migration
+  def self.up
+    change_column :projects, :extensions, :string, :default => []
+    Project.where(:extensions => nil).update_all(:extensions => [])
+  end
+
+  def self.down
+    change_column :projects, :extensions, :string, :default => nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150217151142) do
+ActiveRecord::Schema.define(:version => 20150223141212) do
 
   create_table "auth_sources", :force => true do |t|
     t.string   "type",              :limit => 30, :default => "",    :null => false
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(:version => 20150217151142) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "archived",    :default => false
-    t.string   "extensions"
+    t.string   "extensions",  :default => "--- []\n"
   end
 
   create_table "recipe_versions", :force => true do |t|

--- a/lib/capsize/capsize_setup.rb
+++ b/lib/capsize/capsize_setup.rb
@@ -8,20 +8,6 @@ namespace :load do
   end
 end
 
-task :custom_log do
-  deployment = Deployment.find(ENV['deployment_id'])
-
-  line_number = $stdout.lineno
-  $stdout.rewind
-
-  $stdout.each_line do |line|
-    deployment.log = (deployment.log || '') + line if $stdout.lineno > line_number
-  end
-  deployment.save!
-
-  Rake::Task["custom_log"].reenable
-end
-
 def capsize_setup(stage)
   Rake::Task.define_task(stage.name) do
     set(:stage, stage.name.to_sym)

--- a/lib/capsize/deployer.rb
+++ b/lib/capsize/deployer.rb
@@ -201,7 +201,8 @@ module Capsize
       when Net::SSH::AuthenticationFailed
         logger.important "authentication failed for `#{error.message}'"
       else
-        logger.important error.message + "\n" + error.backtrace.join("\n")
+        @deployment.log = (@deployment.log || '') + error.message + "\n" + error.backtrace.join("\n")
+        @deployment.save!
       end
     end
 

--- a/lib/capsize/deployer.rb
+++ b/lib/capsize/deployer.rb
@@ -110,8 +110,7 @@ module Capsize
 
       write_out.close
       read_out.each_line do |line|
-        @deployment.log = (@deployment.log || '') + line
-        @deployment.save!
+        append_log line
       end
       write.close
       result = read.read
@@ -201,9 +200,13 @@ module Capsize
       when Net::SSH::AuthenticationFailed
         logger.important "authentication failed for `#{error.message}'"
       else
-        @deployment.log = (@deployment.log || '') + error.message + "\n" + error.backtrace.join("\n")
-        @deployment.save!
+        append_log error.message + "\n" + error.backtrace.join("\n")
       end
+    end
+
+    def append_log(line)
+      @deployment.log = (@deployment.log || '') + line
+      @deployment.save!
     end
 
     def find_or_create_project_dir

--- a/lib/capsize/deployer.rb
+++ b/lib/capsize/deployer.rb
@@ -13,7 +13,7 @@ module Capsize
     attr_accessor :deployment
 
     attr_accessor :logger
-    
+
     def initialize(deployment)
       @options = {
         :recipes => [],
@@ -268,10 +268,6 @@ module Capsize
       Capistrano::Application.invoke("rvm:hook")
       Capistrano::Application.invoke("rvm:check")
       Capistrano::Application.invoke("bundler:map_bins")
-    end
-
-    def after_flow(task)
-      "after '#{task}', :custom_log"
     end
   end
 end

--- a/test/unit/capsize_deployer_test.rb
+++ b/test/unit/capsize_deployer_test.rb
@@ -294,13 +294,12 @@ class Capsize::DeployerTest < ActiveSupport::TestCase
 
   def test_output_logs_in_browser_log
     deployer = Capsize::Deployer.new(@deployment)
-    deployer.set_output
-    print 'thisshouldshowup'
-    deployer.close_output
+    deployer.run_in_isolation do
+      print 'thisshouldshowup'
+    end
     assert $stdout == STDOUT
-    deployer.browser_log.rewind
 
-    assert_match /thisshouldshowup/, deployer.browser_log.string
+    assert_match /thisshouldshowup/, @deployment.log
   end
 
   def test_tasks_load

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -184,4 +184,13 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal project.extensions, []
   end
 
+  def test_setting_extensions
+    project = Project.new
+    project.extensions.push("foo")
+    assert project.extensions.include? "foo"
+    project.attributes["extensions"] = ["bar"]
+    project.extensions.push("foo")
+    assert project.extensions.include? "foo"
+  end
+
 end


### PR DESCRIPTION
The logger now reads the stdout within `run_in_isolation` rather than using the rake task.  It streams the output better than before but still appears in sizable chunks.
