### PR TITLE
Fix: add missing tilde in unicorn_restart_cmd()

### DIFF
--- a/lib/capsize/template/unicorn.rb
+++ b/lib/capsize/template/unicorn.rb
@@ -31,7 +31,7 @@ module Capsize
         end
 
         def unicorn_restart_cmd
-          "kill -USR2 `cat #{unicorn_pid}"
+          "kill -USR2 `cat #{unicorn_pid}`"
         end
       
         namespace :capsize do


### PR DESCRIPTION
References https://github.com/peritor/webistrano/pull/57
